### PR TITLE
made navbar permanently sticky, clicking on it jumps to top of page

### DIFF
--- a/src/components/Navigation/NavMenu.js
+++ b/src/components/Navigation/NavMenu.js
@@ -48,12 +48,20 @@ export default function NavMenu(props) {
     </Fragment>
   );
 
+  const scrollToTop = () =>{
+    window.scrollTo({
+      top: 0,
+      behavior: 'auto'
+    })
+  };
+
   return (
     <div className="navigation-container" ref={props.element}>
       <section
         className={`flex ${
           props.sticky ? "navigation-sticky navigation" : "navigation"
         }`}
+        onClick={scrollToTop}
       >
         <div className="navigation-links-container">{links}</div>{" "}
       </section>

--- a/src/components/Navigation/_Navigation.scss
+++ b/src/components/Navigation/_Navigation.scss
@@ -16,7 +16,10 @@ $nav-link-margin: 0 10px;
   width: 100%;
 
   section.navigation {
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 99;
     padding: 0;
     margin: 0;
     background: $hacs-blue;


### PR DESCRIPTION
This closes #89 

Issue 89 says that clicking the navbar should automatically send a user to the top of the page. This would not really make sense if the navbar disappeared after a single scroll downwards, since then it could not be clicked on to return to top. 

Therefore, I made the navbar permanently sticky and it now jumps to the top of the page when clicked.