### PR TITLE
Syntax highlighting to code blocks in MD files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,31 +46,31 @@ Please make sure you have completed the [Pre-Setup Setup](#pre-setup-setup) step
 
 Open up your terminal of choice. Change into a good directory for all things HACS web dev! (i.e. hacs-webdev/)
 
-```
+```bash
 cd hacs-webdev
 ```
 
 Clone the [hacs-frontend](https://github.com/texas-HACS/hacs-frontend) repository:
 
-```
+```bash
 git clone https://github.com/texas-HACS/hacs-frontend.git
 ```
 
 Navigate into the project:
 
-```
+```bash
 cd hacs-frontend
 ```
 
 And install the npm dependencies:
 
-```
+```bash
 npm install --legacy-peer-deps
 ```
 
 OR
 
-```
+```bash
 npm i --legacy-peer-deps
 ```
 
@@ -85,7 +85,7 @@ Save this file to the root of the hacs-frontend project. This means that .env sh
 **_IMPORTANT:_** Please do not share the file or any of its contents with anyone. You won't be doing any good to us and this will just be a nuisance.
 
 **_MAC USERS:_** You may not be able to rename this file properly using just Finder. Once you have placed the env file in the correct location, open up the terminal, navigate to `hacs-frontend`, and perform the following command:
-```
+```bash
 mv env .env
 ```
 This will rename env to .env, which is able to be done at the terminal level, but not in Finder.
@@ -94,7 +94,7 @@ This will rename env to .env, which is able to be done at the terminal level, bu
 
 You can then start the development server for our frontend:
 
-```
+```bash
 npm start
 ```
 

--- a/guides/1_intro_to_web_dev.md
+++ b/guides/1_intro_to_web_dev.md
@@ -11,11 +11,11 @@ Javascript is used to add functionality to the website and is the only one of th
 # HTML
 Hypertext Markup Language, or HTML is the standard markup language for documents displayed on a web browser
 The basic syntax is a piece of content enclosed within an HTML tag like this:
-```
+```html
 <body>This is where the web page's content will be placed</body>
 ```
 Most tags have a closing tag like the one shown above while other don't like the one below:
-```
+```html
 <img src="" alt="">
 ```
 Most if not all tags have attributes which act as parameters and provide more detail on how the content is displayed. `src` and `alt` shown above are two examples of attributes. Another two attributes `id` and `class` are used to apply styles from a .css file. There are many other attributes that vary in function.
@@ -42,12 +42,12 @@ An example of this is shown below:
 There are also three different ways to apply CSS:
 - Inline style which uses the style attribute to style a single specific element
 
-    ```
+    ```html
     <span style="font-size: 16pt">Inline Style Example</span>
     ```
 - Embedded stylesheet which uses the `<style>` tag to define CSS rules
 
-    ```
+    ```html
     <style>
         span {
             font-size: 16pt;
@@ -56,7 +56,7 @@ There are also three different ways to apply CSS:
     ```
 - External stylesheet which involves placing all of your CSS in a separate .css file and is imported using the `<link>` tag. The .css file will have the same format as the image shown above while the link tag should look something like this:
 
-    ```
+    ```html
     <link href="styles.css" rel="stylesheet">
     ```
 

--- a/guides/4_functional_react.md
+++ b/guides/4_functional_react.md
@@ -7,7 +7,7 @@ As mentioned in `developing_in_react.md`, there are two ways to code in React: F
 Functional React involves the use of Javascript functions to create components of a website's frontend, unlike Class-based React which uses classes instead.
 
 An example of a component made with functional React can be found below:
-```
+```js
 import React from "react";
 import { Link } from "react-router-dom";
 import Socials from "../partials/Socials";

--- a/guides/5_git_github_and_version_control.md
+++ b/guides/5_git_github_and_version_control.md
@@ -29,7 +29,7 @@ Also called a "repo", a repository is a location in which software packages are 
 Oftentimes, these repositories are created and managed on version control/hosting sites like [GitHub](https://github.com).
 
 ## Cloning a Repository
-```
+```bash
 git clone https://github.com/texas-HACS/hacs-frontend.git
 ```
 When you create a repository on GitHub (or any other remote service), it exists as a remote repository. You can **clone** your repository to create a local copy on your computer and sync between the two locations.
@@ -37,7 +37,7 @@ When you create a repository on GitHub (or any other remote service), it exists 
 Running the listed command will copy the current state of the hacs-frontend repository into a new directory (folder) named hacs-frontend at the current location on your local machine.
 
 ## Commits
-```
+```bash
 git commit -m "Description of the changes in this commit..."
 ```
 A commit can be seen as a revision to a set of files. Git will create a unique ID to record the changes made in the current commit.
@@ -49,11 +49,11 @@ Files can be added to be "staged" for a commit. This creates a distinction betwe
 
 ### Adding files to a commit
 Since a commit tracks revisions to a set of files, these changes need to be added prior to committing. There are a few ways to do so.
-```
+```bash
 git add -A
 ```
 This will add all current changes to be "staged" for a commit.
-```
+```bash
 git add <path to file>
 ```
 This will add the specified file (file.js, located in path/to/) to be "staged" for the next commit.
@@ -61,7 +61,7 @@ This will add the specified file (file.js, located in path/to/) to be "staged" f
 From this point, the staged files will be included in the next commit.
 
 ## Status
-```
+```bash
 git status
 ```
 This is a great command to let you see the current state of the working directory and staged files. From here, you can see the current branch, staged changes, other changes, current state compared to the remote repository, etc.
@@ -72,43 +72,43 @@ A branch is a version of the repository that diverges from the main working proj
 All other branches hold the state of the main branch (from the point at which they diverged), plus the changes found in the commits on that branch.
 
 ### Create a branch
-```
+```bash
 git branch <branch-name>
 ```
 This creates a new local branch, which will hold the current state of its parent branch. See how to [switch to a branch](#switch-to-a-branch) after creating it.
 
 A condensed way of creating and switching to a new branch is the following:
-```
+```bash
 git checkout -b <branch-name>
 ```
 
 ### Switch to a branch
-```
+```bash
 git checkout <branch-name>
 ```
 This "checks out" or switches to the target branch for you to make changes on the branch.
 
 ### Delete a branch
-```
+```bash
  git branch -d <branch name>  
 ```
 This deletes the target branch from the local repository. If the branch has unmerged changes (any commits since it diverged), extra precautions must be taken.
 
 ### List all local branches
-```
+```bash
 git branch
 ```
 This shows you all branches in the local repository, with the currently active branch being denoted by a *.
 
 ### Merging a branch
-```
+```bash
 git merge <branch name>
 ```
 Please read about [merging](#merge) prior to working with this command.
 This "merges" all changes of the target branch into the current branch.
 
 ## Merge
-```
+```bash
 git merge <branch name>
 ```
 Merging is the process of combining multiple sequences of changes into a single unified history. Most often, this is done by combining two branches.
@@ -147,7 +147,7 @@ This is an example of the file after accepting both sets of changes.
 
 ### Finalizing a merge conflict
 Git will hold a status indicating that you are currently resolving a merge conflict until a commit is made to resolve all conflicts. In order to resolve it, add all changed files from your conflict resolution and commit them.
-```
+```bash
 git add <resolved file>
 git commit -m "Resolved merge conflict by accepting both changes"
 ```
@@ -160,7 +160,7 @@ In the case that this cannot be done, it is important to effectively communicate
 Prior to committing and resolving, test all changes and reach out to previous owners of the code (if at all possible) to clarify the changes.
 
 ## Push
-```
+```bash
 git push
 ```
 This updates the remote repository with your local state, and is essential in aligning work with other contributors.


### PR DESCRIPTION
Only added some simple syntax highlighting to the code blocks in the markdown files. Maybe it will add some visual niceness.
The `bash` annotation for the git examples don't really add much so I was unsure to even add the annotation but for uniformity-sake, I decided to add it.