### PR TITLE
De-clutter navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You will need:
 - node.js [(install)](https://nodejs.org/en/), specifically version 16
   - or use `homebrew` (macOS only)
 - git [(install)](https://git-scm.com/downloads)
-- a text editor of your choice or IDE. [Brackets](https://brackets.io/), [VSCode](https://code.visualstudio.com/download), and [Webstorm](https://www.jetbrains.com/webstorm/download/) are all great.
+- a text editor of your choice or IDE. [VSCode](https://code.visualstudio.com/download), and [Webstorm](https://www.jetbrains.com/webstorm/download/) are both great options.
 - a terminal to access the command line
   - see 
 [`Intro to the Command Line`](https://github.com/texas-HACS/hacs-frontend/blob/master/guides/intro_to_the_command_line.md) in our [guides](https://github.com/texas-HACS/hacs-frontend/tree/master/guides/)

--- a/src/components/Navigation/BurgerMenu.js
+++ b/src/components/Navigation/BurgerMenu.js
@@ -44,25 +44,25 @@ export default function BurgerMenu(props) {
         <div className="nav-link">Opportunities</div>
       </Link>
       <Link to="/newsletter" onClick={() => toggleMenu(false)}>
-        <div className="nav-link">Newsletter</div>
+        <div className="nav-link">Mailing List</div>
       </Link>
-      <Link to="/develop" onClick={() => toggleMenu(false)}>
+      { /* <Link to="/develop" onClick={() => toggleMenu(false)}>
         <div className="nav-link">Develop</div>
-      </Link>
+      </Link> */}
       {/* <Link to="/contact" onClick={() => toggleMenu(false)}>
               <div className="nav-link">Contact</div>
             </Link> */}
       <Link to="/sponsorship" onClick={() => toggleMenu(false)}>
         <div className="nav-link">Sponsorship</div>
       </Link>
-      <Link to="/sign-in" onClick={() => toggleMenu(false)}>
+      { /*<Link to="/sign-in" onClick={() => toggleMenu(false)}>
         <div className="nav-link">Sign In</div>
-      </Link>
-      <Link to="/admin" aria-label="admin" onClick={() => toggleMenu(false)}>
+      </Link> */}
+      { /* <Link to="/admin" aria-label="admin" onClick={() => toggleMenu(false)}>
         <div className="nav-link">
           <i className="fas fa-cog" />
-        </div>
-      </Link>
+        </div> 
+      </Link> */}
     </section>
   );
 

--- a/src/components/Navigation/NavMenu.js
+++ b/src/components/Navigation/NavMenu.js
@@ -34,25 +34,25 @@ export default function NavMenu(props) {
       </Link>
       {/* target opens a new tab so when making their pages remove them */}
       <Link to="/newsletter" target={newsletterLink?.target}>
-        <div className="nav-link">Newsletter</div>
+        <div className="nav-link">Mailing List</div>
       </Link>
-      <Link to="/develop" target={developLink?.target}>
-        <div className="nav-link">Develop</div>
-      </Link>
+      { /* <Link to="/develop" target={developLink?.target}>
+        <div className="nav-link">Develop</div> 
+      </Link> */}
       {/* <Link to="/contact" onClick={()=>props.tm(false)}>
               <div className="nav-link">Contact</div>
             </Link> */}
       <Link to="/sponsorship">
         <div className="nav-link">Sponsorship</div>
       </Link> 
-      <Link to="/sign-in">
+      { /* <Link to="/sign-in">
         <div className="nav-link">Sign In</div>
-      </Link>
-      <Link to="/admin">
+      </Link> */}
+      { /* <Link to="/admin">
         <div className="nav-link">
           <i className="fas fa-cog" />
         </div>
-      </Link>
+      </Link> */}
       {/* The TestNavLink below should only be used in cases where you want to test how things will
       render on the website. Make sure to comment it out before pushing to github. To test things
       just add your code to TestPage.js */}


### PR DESCRIPTION
I personally think the navbar is a bit cluttered as-is, with 9 items.
- Removed the "develop" part of it, it would probably be better to just be a section in the footer.
- Remove the "Sign In" section, as most people just scan the qr-code during meetings. I don't think many navigate to the hacs website to click it, especially as the navbar isn't immediately visible on mobile.
- Remove the settings icon. Since it's just an admin thing, i don't think it should be on the public website, if needed I think it would be better to just manually type in the link. 
- Changed "Newsletter" to be "Mailing List". The newsletter doesn't seem to be maintained anymore, and I don't know if we still use the mailing list, maybe remove in future?

Also, I just removed Brackets to be a suggested IDE in the readme because it isn't actively maintained anymore.